### PR TITLE
0722 김태완 frontend 변경점 오전

### DIFF
--- a/frontend/src/components/MapSidebar.css
+++ b/frontend/src/components/MapSidebar.css
@@ -242,3 +242,42 @@
     height: 16px;
     cursor: pointer;
 }
+
+.mobile-sidebar-close-button {
+    display: none; /* 기본적으로 숨김 */
+}
+
+@media (max-width: 700px) {
+    .map-sidebar-container {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 70vh;
+        transform: translateY(100%);
+        transition: transform 0.3s ease-in-out;
+        border-right: none;
+        border-top: 1px solid #e0e0e0;
+        z-index: 1100;
+    }
+
+    .map-sidebar-container.open {
+        transform: translateY(0);
+    }
+
+    .sidebar-toggle-button {
+        display: none; /* 모바일에서는 기존 토글 버튼 숨김 */
+    }
+
+    .mobile-sidebar-close-button {
+        display: block; /* 모바일에서만 표시 */
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        background: none;
+        border: none;
+        font-size: 24px;
+        cursor: pointer;
+        z-index: 1200;
+    }
+}

--- a/frontend/src/components/MapSidebar.js
+++ b/frontend/src/components/MapSidebar.js
@@ -25,6 +25,8 @@ const MapSidebar = ({
   searchResults,
   currentKeyword,
   onResultItemClick,
+  isOpen,
+  onClose,
 }) => {
   /* viewer info (NULL when not logged‑in) */
   const { user } = useAuth();
@@ -118,7 +120,8 @@ const MapSidebar = ({
 
   /* ───────────────────────── render ───────────────────────── */
   return (
-    <div className={`map-sidebar-container ${isCollapsed ? "collapsed" : ""}`}>
+    <div className={`map-sidebar-container ${isCollapsed ? "collapsed" : ""} ${isOpen ? "open" : ""}`}>
+      <button className="mobile-sidebar-close-button" onClick={onClose}>×</button>
       <div className="sidebar-content">
         <p className="map-logo" onClick={goToHomePage} style={{ cursor: "pointer" }}>
           GUMIO

--- a/frontend/src/components/PostDetailModalContent.css
+++ b/frontend/src/components/PostDetailModalContent.css
@@ -199,7 +199,7 @@
     }
 }
 
-@media (max-width: 360px) {
+@media (max-width: 700px) {
     .post-detail-modal-content {
         flex-direction: column; /* 세로 정렬 */
         width: 100%; /* 전체 너비 사용 */

--- a/frontend/src/components/PostList.js
+++ b/frontend/src/components/PostList.js
@@ -116,7 +116,7 @@ function PostList({
           <p className="no-results">
             {searchTerm
               ? `"${searchTerm}"에 대한 결과가 없습니다.`
-              : "게시물이 없습니다."}
+              : "게시물을 불러오는 중입니다"}
           </p>
         )}
       </div>

--- a/frontend/src/components/WordCloud.js
+++ b/frontend/src/components/WordCloud.js
@@ -9,8 +9,8 @@ import { WordCloud as LibWordCloud } from "@isoterik/react-word-cloud";
 
 /* Map sentiment (if any) → colour. */
 const sentimentColour = (s) => {
-  if (s === 1 || s === "positive" || s === "pos") return "#16a34a"; // green‑600
-  if (s === -1 || s === "negative" || s === "neg") return "#dc2626"; // red‑600
+  if (s === 1 || s === "positive" || s === "pos") return "#99DAA9"; // green‑600
+  if (s === -1 || s === "negative" || s === "neg") return "#F59B9B"; // red‑600
   return "#6b7280";                                                  // gray‑500
 };
 
@@ -42,6 +42,8 @@ const MyWordCloud = ({
       fontSize={(w) => 12 + Math.sqrt(w.value) * 6}
       fill={(w) => w.fill}
       deterministic
+      fontWeight={"bold"}
+      font={"IBM_Plex_Sans_KR"}
     />
   );
 };

--- a/frontend/src/pages/MapPage.css
+++ b/frontend/src/pages/MapPage.css
@@ -18,3 +18,24 @@
     height: 100%;
     background-color: #f0f0f0; /* 지도 로딩 전 배경색 */
 }
+
+.mobile-sidebar-toggle-button {
+    display: none; /* 기본적으로 숨김 */
+}
+
+@media (max-width: 700px) {
+    .mobile-sidebar-toggle-button {
+        display: block; /* 모바일에서만 표시 */
+        position: absolute;
+        bottom: 20px;
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: 1000;
+        padding: 10px 20px;
+        background-color: #672091;
+        color: #fff;
+        border: none;
+        border-radius: 20px;
+        cursor: pointer;
+    }
+}

--- a/frontend/src/pages/MapPage.js
+++ b/frontend/src/pages/MapPage.js
@@ -31,6 +31,7 @@ function MapPage() {
     const [searchResults, setSearchResults] = useState([]);
     // 현재 검색어를 저장하는 상태
     const [keyword, setKeyword] = useState('');
+    const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
     // 현재 위치를 가져오는 함수 (Geolocation API 우선 사용, 실패 시 ipinfo.io 폴백)
     const fetchCurrentLocation = useCallback(async () => {
@@ -259,9 +260,14 @@ function MapPage() {
                             mapInstance.current.setCenter(new window.kakao.maps.LatLng(place.y, place.x));
                         }
                     }}
+                    isOpen={isSidebarOpen}
+                    onClose={() => setIsSidebarOpen(false)}
                 />
                 {/* 지도 영역 */}
                 <main id="map" className="map-area" ref={mapContainer}></main>
+                <button className="mobile-sidebar-toggle-button" onClick={() => setIsSidebarOpen(true)}>
+                    탐색
+                </button>
             </div>
         </div>
     );

--- a/frontend/src/pages/MyPage.css
+++ b/frontend/src/pages/MyPage.css
@@ -92,15 +92,15 @@
 .post-right-part {
   flex: 1; /* 오른쪽 부분이 더 좁게 */
 }
-.word-cloud-container {
+.mypage-word-cloud-container {
   display: flex;
   flex-direction: column;
   gap: 12px;                      /* spacing between title & cloud */
   align-items: center;
   justify-content: flex-start;
-  border: 1px solid #ddd;         /* straight solid line */
+  border: none;         /* straight solid line */
   border-radius: 8px;
-  background-color: #f9f9f9;
+  background-color: #ffffff;
   padding: 20px;
   height: 420px;                  /* matches thumbnail height nicely */
   box-sizing: border-box;
@@ -114,7 +114,7 @@
   text-align: center;
 }
 
-.word-cloud-content {
+.mypage-word-cloud-content {
   flex: 1;                        /* fill remaining height */
   width: 100%;                    /* take full width */
   display: flex;
@@ -125,7 +125,7 @@
 }
 
 /* optional: limit SVG to container size */
-.word-cloud-content svg {
+.mypage-word-cloud-content svg {
   max-width: 100%;
   max-height: 100%;
 }
@@ -150,7 +150,7 @@
     }
 
     .user-info-right {
-        flex-direction: column; /* 세로 정렬 */
+        flex-direction: row; /* 세로 정렬 */
         align-items: flex-start; /* 왼쪽 정렬 */
         gap: 10px; /* 간격 조정 */
         width: 100%; /* 전체 너비 사용 */
@@ -158,7 +158,7 @@
 
     .user-info-item {
         width: 100%; /* 전체 너비 사용 */
-        text-align: left; /* 텍스트 왼쪽 정렬 */
+        text-align: center; /* 텍스트 왼쪽 정렬 */
     }
 
     .my-user-post {
@@ -171,7 +171,13 @@
         width: 100%; /* 전체 너비 사용 */
     }
 
-    .word-cloud-container {
+    .mypage-word-cloud-container {
         height: auto; /* 높이 자동 조절 */
+        max-width: 600px;
+        height: 200px;
+    }
+
+    .my-user-post.mobile-layout {
+        flex-direction: column-reverse;
     }
 }

--- a/frontend/src/pages/MyPage.js
+++ b/frontend/src/pages/MyPage.js
@@ -44,6 +44,7 @@ const MyPage = () => {
   const [followingCount,  setFollowingCount]  = useState(0);
   const [postCount,       setPostCount]       = useState(0);
   const [keywords,        setKeywords]        = useState([]);
+  const [windowWidth,     setWindowWidth]     = useState(window.innerWidth); // 워드클라우드 크기 변경
 
   /* UX flags */
   const [loading, setLoading] = useState(true);
@@ -141,6 +142,13 @@ const MyPage = () => {
   /* ------------------------------------------------------------------ */
   /* Lifecycle                                                          */
   /* ------------------------------------------------------------------ */
+  // 워드클라우드 크기 변경
+  useEffect(() => {
+    const handleResize = () => setWindowWidth(window.innerWidth);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -214,16 +222,19 @@ const MyPage = () => {
             </div>
 
             {/* Posts + word‑cloud */}
-            <div className="my-user-post">
+            <div className={`my-user-post ${window.innerWidth <= 700 ? 'mobile-layout' : ''}`}>
               <section className="post-left-part">
                 <PostList isMyPage={true} user_id={userID} columns={1} />
               </section>
 
               <aside className="post-right-part">
-                <div className="word-cloud-container">
-                  <h3 className="word-cloud-title">워드&nbsp;클라우드</h3>
-                  <div className="word-cloud-content">
-                    <WordCloud keywords={keywords} />
+                <div className="mypage-word-cloud-container">
+                  <div className="mypage-word-cloud-content">
+                    <WordCloud 
+                      keywords={keywords}
+                      width={windowWidth <= 700 ? 600 : 300}
+                      height={windowWidth <= 700 ? 200 : 300}
+                    /> 
                   </div>
                 </div>
               </aside>

--- a/frontend/src/pages/OthersPage.css
+++ b/frontend/src/pages/OthersPage.css
@@ -6,21 +6,23 @@
 
 /* follow button */
 .follow-button button {
-  padding: 6px 18px;
-  border: 1px solid #ff7b00;
-  border-radius: 20px;
-  background: #fff;
+  padding: 5px 3px;
+  border: 1px solid #672091;
+  border-radius: 8px;
+  background: white;
   font-size: 0.9rem;
   cursor: pointer;
   transition: background 0.2s ease;
+  min-width: 75px; /* Add this line */
+  text-align: center; /* Add this line */
 }
 .follow-button button:hover {
-  background: #ffe6cc;
+  background: #6820917e;
 }
 .follow-button button.following {
-  background: #ff7b00;
-  border-color: #ff7b00;
-  color: #fff;
+  background: #672091;
+  border-color: #672091;
+  color: white;
 }
 .follow-button button:disabled {
   opacity: 0.5;

--- a/frontend/src/pages/OthersPage.js
+++ b/frontend/src/pages/OthersPage.js
@@ -38,6 +38,7 @@ const OthersPage = () => {
   const [postCount,      setPostCount]      = useState(0);
   const [keywords,       setKeywords]       = useState([]);
   const [isFollowing,    setIsFollowing]    = useState(false);
+  const [windowWidth,     setWindowWidth]     = useState(window.innerWidth); // 워드클라우드 크기 변경
 
   /* UX flags */
   const [loading, setLoading] = useState(true);
@@ -73,6 +74,13 @@ const OthersPage = () => {
     const ids = (following ?? []).map(u => u.user_id);
     setIsFollowing(ids.includes(targetId));
   }, [viewerId, targetId]);
+
+  // 워드클라우드 크기 변경
+  useEffect(() => {
+    const handleResize = () => setWindowWidth(window.innerWidth);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
 
   /* initial load */
   useEffect(() => {
@@ -144,23 +152,26 @@ const OthersPage = () => {
                     className={isFollowing ? "following" : ""}
                     disabled={!viewerId || viewerId === targetId}
                   >
-                    {viewerId === targetId ? "본인" : isFollowing ? "following" : "follow"}
+                    {viewerId === targetId ? "본인" : isFollowing ? "팔로잉" : "팔로우"}
                   </button>
                 </div>
               </div>
             </div>
 
             {/* posts + word-cloud */}
-            <div className="my-user-post">
+            <div className={`my-user-post ${window.innerWidth <= 700 ? 'mobile-layout' : ''}`}>
               <section className="post-left-part">
                 <PostList user_id={targetId} columns={1} />
               </section>
 
               <aside className="post-right-part">
-                <div className="word-cloud-container">
-                  <h3 className="word-cloud-title">워드&nbsp;클라우드</h3>
-                  <div className="word-cloud-content">
-                    <WordCloud keywords={keywords} />
+                <div className="mypage-word-cloud-container">
+                  <div className="mypage-word-cloud-content">
+                    <WordCloud 
+                      keywords={keywords}
+                      width={windowWidth <= 700 ? 600 : 300}
+                      height={windowWidth <= 700 ? 200 : 300}
+                    />
                   </div>
                 </div>
               </aside>

--- a/frontend/src/pages/RegisterPage.css
+++ b/frontend/src/pages/RegisterPage.css
@@ -216,6 +216,35 @@ input[type="date"]::-webkit-datetime-edit-year-field {
     transition: background-color 0.2s ease;
 }
 
+@media (max-width: 700px) {
+    .form-row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
+    }
+
+    .register-input-group label {
+        width: auto;
+        margin-bottom: 5px;
+    }
+
+    .input-with-button {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
+    }
+
+    .register-input-group input[type='text'],
+    .register-input-group input[type='email'] {
+        width: 100%;
+        box-sizing: border-box;
+    }
+
+    .duplicate-check-button {
+        width: 100%;
+    }
+}
+
 .register-submit-button:hover {
     background-color: #672091;
     color: rgba(250, 240, 210, 1);

--- a/frontend/src/pages/RestaurantInfoPage.css
+++ b/frontend/src/pages/RestaurantInfoPage.css
@@ -51,6 +51,7 @@
 .restaurant-name {
     font-size: 2rem;
     font-weight: bold;
+    margin-top: 10px;
     margin-bottom: 10px;
     align-self: flex-start;
 }
@@ -58,25 +59,25 @@
 .restaurant-address {
     font-size: 1.1rem;
     color: #555;
-    margin-bottom: 20px;
+    margin-top: 10px;
+    margin-bottom: 10px;
     align-self: flex-start;
 }
 
 /* ───────── Word‑cloud box – matches thumbnail width ───────── */
 .word-cloud-container {
     width: 100%;            /* stretch inside flex column */
-    max-width: 400px;       /* identical to .restaurant-image */
+    max-width: 600px;       /* identical to .restaurant-image */
     display: flex;
     flex-direction: column;
     gap: 12px;
     align-items: center;
     justify-content: flex-start;
-    border: 1px solid #ddd;
-    border-radius: 8px;
-    background-color: #f9f9f9;
-    padding: 20px;
-    height: 420px;
+    background-color: #ffffff;
+    padding: 10px;
+    height: 150px;
     box-sizing: border-box;
+    border: none;
 }
 
 .word-cloud-title {
@@ -98,4 +99,22 @@
 .word-cloud-content svg {
     max-width: 100%;
     max-height: 100%;
+}
+
+@media (max-width: 700px) {
+
+    .restaurantInfopage-layout {
+        width: 100%;
+    }
+
+    .rIpage-middle-area {
+        flex-direction: column;
+        margin-top: 20px;
+    }
+
+    .rIpage-left-part,
+    .rIpage-right-part {
+        width: 100%;
+        padding-right: 0;
+    }
 }

--- a/frontend/src/pages/RestaurantInfoPage.js
+++ b/frontend/src/pages/RestaurantInfoPage.js
@@ -80,11 +80,12 @@ function RestaurantInfoPage() {
               {/* Word‑cloud – same width as thumbnail */}
               {restaurant.keywords.length > 0 && (
                 <div className="word-cloud-container">
-                  <h3 className="word-cloud-title">워드&nbsp;클라우드</h3>
                   <div className="word-cloud-content">
                     <WordCloud
                       keywords={restaurant.keywords}
-                      uniformColour="#7c3aed"   /* violet‑500 */
+                      uniformColour="#672091"   /* violet‑500 */
+                      height={150}
+                      width={600}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
수정:
PostDetailModelContent.css : 화면 너비 700px이하 일때 화면 비율 조정

RegisterPage.css : 화면 너비 700px이하 일때 화면 비율 조정

MyPage.js : 
- 워드클라이드 단어 제거. 워드 클라우드 classname 변경
- 화면 너비 700px이하 일때 PostList와 워드클라우드 위치 변경을 위한 div 추가
- 화면 너비 700px이하 일때 워드클라우드의 크기 변경 로직 추가
MyPage.css : 
- 화면 너비 700px이하 일때 '팔로워', '팔로잉', '게시물' 가로줄로 배치되도록 변경. 
- 화면 너비 700px이하 일때 PostList와 워드클라우드 위치 변경
- 화면 너비 700px이하 일때 워드클라우드 영역 변경


OhtersPage.js : 
- follow-button의 글자 영어에서 한글로 변경
- 화면 너비 700px이하 일때 워드클라우드의 크기 변경 로직 추가

OthersPage.css : 
- MyPage.css를 변경하면서 MyPage.css를 import받고 있어서 자동적으로 변경. 
- follow-button 클릭시 '팔로워', '팔로잉', '게시물' 위치가 변경되는 것을 변경되지 않도록 수정

RestaurantPage.js
RestaurantPage.css  : 
- 화면 너비 700px이하 일때 화면 비율 조정
- 워드 클라우드 모양과 크기 변경

PostList.js : 게시물이 없습니다 > 게시물을 불러오는 중입니다 변경

WordCloud.js : IBM 폰트 적용. 긍정과 부정 색상 변경

MapSidebar.js  MapSidebar.css :
- 모바일 환경에 맞춰 조정

MapPage.js  MapPage.css :
- 모바일 환경에 맞춰 조정